### PR TITLE
Handle null strings when sorting by StringOrdComparator

### DIFF
--- a/bobo-browse/src/main/java/com/browseengine/bobo/sort/SortCollectorImpl.java
+++ b/bobo-browse/src/main/java/com/browseengine/bobo/sort/SortCollectorImpl.java
@@ -49,13 +49,13 @@ public class SortCollectorImpl extends SortCollector {
       Comparable s2 = o2.getValue();
      
       int r;
-      if (s1 == null) {
-        if (s2 == null) {
+      if ((s1 == null) || ((s1 instanceof String) && s1.equals("null"))) {
+        if ((s2 == null) || ((s2 instanceof String) && s2.equals("null"))) {
           r = 0;
         } else {
           r = -1;
         }
-      } else if (s2 == null) {
+      } else if ((s2 == null) || ((s2 instanceof String) && s2.equals("null"))) {
         r = 1;
       }
       else{


### PR DESCRIPTION
When using StringOrdComparator, it returns null values as "null", which the SortCollector comparator does not check for when sorting.  This causes the sort to not order properly.  Proposed potential fix.  Thanks!
