### PR TITLE
Handle null values when sorting by StringOrdComparator

### DIFF
--- a/bobo-browse/src/main/java/com/browseengine/bobo/sort/DocComparatorSource.java
+++ b/bobo-browse/src/main/java/com/browseengine/bobo/sort/DocComparatorSource.java
@@ -140,6 +140,10 @@ public abstract class DocComparatorSource {
 				}
 
 				public String value(ScoreDoc doc) {
+					if (values.lookup[values.order[doc.doc]] == null) {
+							return null;
+					}
+
 					return String.valueOf(values.lookup[values.order[doc.doc]]);
 				}
 			};

--- a/bobo-browse/src/main/java/com/browseengine/bobo/sort/ReverseDocComparatorSource.java
+++ b/bobo-browse/src/main/java/com/browseengine/bobo/sort/ReverseDocComparatorSource.java
@@ -50,6 +50,16 @@ public class ReverseDocComparatorSource extends DocComparatorSource {
 			public int compareTo(Object o) {
 				if (o instanceof ReverseComparable){
 					Comparable inner = ((ReverseComparable)o)._inner;						
+
+					if (_inner == null) {
+						if (inner == null) {
+							return 0;
+						}
+						return 1;
+					} else if (inner == null) {
+						return -1;
+					}
+
 					return -_inner.compareTo(inner);
 				}
 				else{


### PR DESCRIPTION
This is a proposed solution in adding null checks to allow sort to work properly when ordering by values that contain null values using StringOrdComparator.
